### PR TITLE
Add support for using `$format` in URL parameters

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -110,12 +110,12 @@
 
 			foreach ($routes as $i => $route)
 			{
-				preg_match_all('/:([0-9a-zA-Z_]+)/', $route['from'], $names, PREG_PATTERN_ORDER);
+				preg_match_all('/[$:]([0-9a-zA-Z_]+)/', $route['from'], $names, PREG_PATTERN_ORDER);
 				$names = $names[0];
 
 				if (!$names) continue;
 
-				$new  = preg_replace('/:[[0-9a-zA-Z_]+/', '([a-zA-Z0-9_\+\-%]+)', $route['from']);
+				$new  = preg_replace('/[$:][[0-9a-zA-Z_]+/', '([a-zA-Z0-9_\+\-%]+)', $route['from']);
 				$new  = '/'. trim($new, '/');
 				$new  = '/'. str_replace('/', "\/", $new);
 				$new .= '/i';
@@ -269,14 +269,14 @@
 				$divgroup->setAttribute('class', 'group');
 				$labelfrom = Widget::Label(__('From'));
 				$labelfrom->appendChild(Widget::Input("settings[url-router][routes][][from]"));
-				$labelfrom->appendChild(new XMLElement('p', 'Simplified: <code>page-name/:user/projects/:project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
+				$labelfrom->appendChild(new XMLElement('p', 'Simplified: <code>page-name/$user/projects/$project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 ')));
 				$labelfrom->appendChild(new XMLElement('p', 'Regular expression: <code>/\/page-name\/(.+\/)/</code> Wrap in <code>/</code> and ensure to escape metacharacters with <code>\\</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 ')));
 
 				$labelto = Widget::Label(__('To'));
 				$labelto->appendChild(Widget::Input("settings[url-router][routes][][to]"));
-				$labelto->appendChild(new XMLElement('p', 'Simplified: <code>/new-page-name/:user/:project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
+				$labelto->appendChild(new XMLElement('p', 'Simplified: <code>/new-page-name/$user/$project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 ')));
 				$labelto->appendChild(new XMLElement('p', 'Regular expression: <code>/new-page-name/$1/</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 ')));
@@ -344,20 +344,20 @@
 
 							$from = $route['from'];
 							if (isset($route['from-clean'])) $from = $route['from-clean'];
-							
+
 							$labelfrom = Widget::Label(__('From'));
 							$labelfrom->appendChild(Widget::Input("settings[url-router][routes][][from]", General::sanitize($from)));
-							$labelfrom->appendChild(new XMLElement('p', 'Simplified: <code>page-name/:user/projects/:project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
+							$labelfrom->appendChild(new XMLElement('p', 'Simplified: <code>page-name/$user/projects/$project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 			')));
 							$labelfrom->appendChild(new XMLElement('p', 'Regular expression: <code>/\/page-name\/(.+\/)/</code> Wrap in <code>/</code> and ensure to escape metacharacters with <code>\\</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 			')));
 
 							$to = $route['to'];
 							if (isset($route['to-clean'])) $to = $route['to-clean'];
-							
+
 							$labelto = Widget::Label(__('To'));
 							$labelto->appendChild(Widget::Input("settings[url-router][routes][][to]", General::sanitize($to)));
-							$labelto->appendChild(new XMLElement('p', 'Simplified: <code>/new-page-name/:user/:project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
+							$labelto->appendChild(new XMLElement('p', 'Simplified: <code>/new-page-name/$user/$project</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 			')));
 							$labelto->appendChild(new XMLElement('p', 'Regular expression: <code>/new-page-name/$1/</code>', array('class' => 'help', 'style' => 'margin: 0.5em 0 -0.5em;
 			')));


### PR DESCRIPTION
Add support for using `$format` in URL parameters in addition to `:format`. Addresses #11.
